### PR TITLE
feat: 댓글 기능 구현

### DIFF
--- a/src/main/java/com/sparta/studycommunity/controller/CommentController.java
+++ b/src/main/java/com/sparta/studycommunity/controller/CommentController.java
@@ -1,0 +1,38 @@
+package com.sparta.studycommunity.controller;
+
+import com.sparta.studycommunity.dto.CommentRequestDto;
+import com.sparta.studycommunity.dto.CommentResponseDto;
+import com.sparta.studycommunity.security.UserDetailsImpl;
+import com.sparta.studycommunity.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.RejectedExecutionException;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/comments")
+    public ResponseEntity<CommentResponseDto> createComment(@RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CommentResponseDto comment = commentService.createComment(requestDto, userDetails.getUser());
+        return ResponseEntity.ok(comment);
+    }
+
+    @PutMapping("/comments/{id}")
+    public ResponseEntity<CommentResponseDto> updateComment(@PathVariable Long id, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CommentResponseDto comment = commentService.updateComment(id, requestDto, userDetails.getUser());
+        return ResponseEntity.ok(comment);
+    }
+
+    @DeleteMapping("/comments/{id}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.deleteComment(id, userDetails.getUser());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sparta/studycommunity/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/studycommunity/dto/CommentRequestDto.java
@@ -1,4 +1,11 @@
 package com.sparta.studycommunity.dto;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class CommentRequestDto {
+    private Long postId;
+    private String contents;
 }

--- a/src/main/java/com/sparta/studycommunity/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/studycommunity/dto/CommentResponseDto.java
@@ -1,4 +1,23 @@
 package com.sparta.studycommunity.dto;
 
+import com.sparta.studycommunity.entity.Comment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
 public class CommentResponseDto {
+    private String contents;
+    private String username;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public CommentResponseDto(Comment comment) {
+        this.contents = comment.getContents();
+        this.username = comment.getUser().getUsername();
+        this.createdAt = comment.getCreatedAt();
+        this.modifiedAt = comment.getModifiedAt();
+    }
 }

--- a/src/main/java/com/sparta/studycommunity/dto/PostResponseDto.java
+++ b/src/main/java/com/sparta/studycommunity/dto/PostResponseDto.java
@@ -1,11 +1,12 @@
 package com.sparta.studycommunity.dto;
 
 import com.sparta.studycommunity.entity.Post;
-import com.sparta.studycommunity.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -16,7 +17,9 @@ public class PostResponseDto {
     private String contents;
     private String image;
     private Integer scrapCount;
-    private User user;
+    private String username;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
     private List<TagResponseDto> postTagList = new ArrayList<>();
     private List<CommentResponseDto> commentList = new ArrayList<>();
 
@@ -26,11 +29,18 @@ public class PostResponseDto {
         this.contents = post.getContents();
         this.image = post.getImage();
         this.scrapCount = post.getScrapCount();
-        this.user = post.getUser();
+        this.username = post.getUser().getUsername();
+        this.createdAt = post.getCreatedAt();
+        this.modifiedAt = post.getModifiedAt();
         this.postTagList = post.getPostTagList()
                             .stream()
                             .map(postTag -> new TagResponseDto(postTag.getTag()))
                             .toList();
-//      this.commentList = post.getCommentList();
+        this.commentList = post.getCommentList()
+                            .stream()
+                            .map(CommentResponseDto::new)
+                            .sorted(Comparator.comparing(CommentResponseDto::getCreatedAt).reversed())
+                            .toList();
+
     }
 }

--- a/src/main/java/com/sparta/studycommunity/dto/TagRequestDto.java
+++ b/src/main/java/com/sparta/studycommunity/dto/TagRequestDto.java
@@ -8,5 +8,5 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class TagRequestDto {
-    List<String> tagNames;
+    private List<String> tagNames;
 }

--- a/src/main/java/com/sparta/studycommunity/entity/Comment.java
+++ b/src/main/java/com/sparta/studycommunity/entity/Comment.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @Table(name = "comments")
-public class Comment {
+public class Comment extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,4 +26,8 @@ public class Comment {
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
+
+    public Comment(String contents) {
+        this.contents = contents;
+    }
 }

--- a/src/main/java/com/sparta/studycommunity/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/studycommunity/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.studycommunity.repository;
+
+import com.sparta.studycommunity.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/sparta/studycommunity/service/CommentService.java
+++ b/src/main/java/com/sparta/studycommunity/service/CommentService.java
@@ -1,0 +1,55 @@
+package com.sparta.studycommunity.service;
+
+import com.sparta.studycommunity.dto.CommentRequestDto;
+import com.sparta.studycommunity.dto.CommentResponseDto;
+import com.sparta.studycommunity.entity.Comment;
+import com.sparta.studycommunity.entity.Post;
+import com.sparta.studycommunity.entity.User;
+import com.sparta.studycommunity.entity.UserRoleEnum;
+import com.sparta.studycommunity.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.RejectedExecutionException;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final PostService postService;
+    private final CommentRepository commentRepository;
+
+    public CommentResponseDto createComment(CommentRequestDto requestDto, User user) {
+        Post post = postService.findPost(requestDto.getPostId());
+        Comment comment = new Comment(requestDto.getContents());
+        comment.setUser(user);
+        comment.setPost(post);
+
+        Comment savedComment = commentRepository.save(comment);
+        return new CommentResponseDto(savedComment);
+    }
+
+    @Transactional
+    public CommentResponseDto updateComment(Long id, CommentRequestDto requestDto, User user) {
+        Comment comment = findComment(id);
+        if (!comment.getUser().equals(user)) {
+            throw new IllegalArgumentException("사용자가 작성한 댓글만 수정 가능합니다.");
+        }
+        comment.setContents(requestDto.getContents());
+        return new CommentResponseDto(comment);
+    }
+
+    public void deleteComment(Long id, User user) {
+        Comment comment = findComment(id);
+        if (!comment.getUser().equals(user)) {
+            throw new IllegalArgumentException("사용자가 작성한 댓글만 삭제 가능합니다.");
+        }
+        commentRepository.delete(comment);
+    }
+
+    private Comment findComment(Long id) {
+        return commentRepository.findById(id).orElseThrow(() -> {
+            throw new IllegalArgumentException("존재하지 않는 댓글입니다.");
+        });
+    }
+}

--- a/src/main/java/com/sparta/studycommunity/service/PostService.java
+++ b/src/main/java/com/sparta/studycommunity/service/PostService.java
@@ -52,7 +52,7 @@ public class PostService {
         return new PostResponseDto(post);
     }
 
-    private Post findPost(Long id) {
+    public Post findPost(Long id) {
         return postRepository.findById(id).orElseThrow(() ->
                 new IllegalArgumentException("해당 게시글이 존재하지 않습니다.")
         );


### PR DESCRIPTION
### 세부 공유 사항

api 설계할 때 댓글 기능은 작성과 삭제까지만 기획했던 걸로 아는데,
우선은 lv3 과제 참고해서 수정 기능까지 추가해 놓았습니다. (나중에 필요없으면 빼는 걸로 해요!)

Comment와 User를 N : 1 단방향 관계로 이해했는데 맞을까요?
사용자가 '내가 작성한 댓글'을 조회할 일은 없을 것 같아서 User 엔티티에 댓글 리스트 필드를 추가하진 않았습니다.